### PR TITLE
render_engine was missing the arguments

### DIFF
--- a/simulate.py
+++ b/simulate.py
@@ -82,7 +82,7 @@ def main():
 
                 try:
                     galaxy = galaxy_builder.from_catalog(entry,dx,dy,survey.filter_band)
-                    stamps,bounds = render_engine.render_galaxy(galaxy)
+                    stamps,bounds = render_engine.render_galaxy(galaxy,args.no_partials,args.calculate_bias)
                     analyzer.add_galaxy(galaxy,stamps,bounds)
                     trace('render')
 


### PR DESCRIPTION
I noticed that in `simulate.py`, `render_engine.render_galaxy` was missing the correct arguments. I added them in this pull request. 