### PR TITLE
Minor update on simulate.py documentation

### DIFF
--- a/docs/programs.rst
+++ b/docs/programs.rst
@@ -39,6 +39,12 @@ You can override any of these defaults on the command line, e.g.::
 
 You can also create new default survey configurations by editing the :mod:`descwl.survey` module.
 
+For the Simulation output to include the bias on the parameters calculated from the Fisher Formalism, one must include the command line argument:: 
+
+	./simulate.py --calculate-bias ... 
+	
+Running this command could significantly increase running time. 
+
 The main simulation parameter is the pixel signal-to-noise threshold, `min-snr`::
 
 	./simulate.py --min-snr 0.1 ...


### PR DESCRIPTION
Pat and I decided that it might be a good idea to make it more explicit in the documentation that the package can calculate biases using the Fisher Formalism. I have included this in the `programs.rst` part of the documentation where `simulate.py` is described, I basically describe the new command line argument `--calculate-bias`. What do you think of this change @dkirkby ? Is there any other part of the documentation where we could mention the capability of calculating biases where it would be better? Thanks! 