### PR TITLE
No analysis (#35)

### DIFF
--- a/descwl/analysis.py
+++ b/descwl/analysis.py
@@ -784,7 +784,7 @@ class OverlapAnalyzer(object):
             bestfit_values[i,5] = parameters['dg2_%d'%i].value
         return bestfit_values
 
-    def finalize(self,verbose,trace,calculate_bias):
+    def finalize(self,verbose,trace,calculate_bias,no_analysis):
         """Finalize analysis of all added stars and galaxies.
 
         Args:
@@ -867,6 +867,13 @@ class OverlapAnalyzer(object):
                 ])
 
         data = np.empty(num_galaxies, dtype=dtype)
+        if no_analysis:
+            # Return empty data table
+            table = astropy.table.Table(data, copy=False)
+            num_slices, h, w = self.stamps[0].shape
+            results = OverlapResults(self.survey, table, self.stamps,
+                                     self.bounds, num_slices)
+            return results
 
         trace('allocated table of %ld bytes for %d galaxies' % (data.nbytes,num_galaxies))
 

--- a/descwl/analysis.py
+++ b/descwl/analysis.py
@@ -901,7 +901,7 @@ class OverlapAnalyzer(object):
             data['ri_color'][index] = model.ri_color
             data['flux'][index] = model.model.flux
             # Is this galaxy's centroid visible in the survey image?
-            data['visible'][index] = 1 if self.survey.image.bounds.includes(bounds.center.pos) else 0
+            data['visible'][index] = 1 if self.survey.image.bounds.includes(bounds.center.x, bounds.center.y) else 0
             if(getattr(model,'disk_fraction',None)!=None):
                 data['f_disk'][index] = model.disk_fraction
                 data['f_bulge'][index] = model.bulge_fraction

--- a/descwl/render.py
+++ b/descwl/render.py
@@ -283,7 +283,6 @@ class Engine(object):
             raise SourceNotVisible
         self.survey.image[survey_overlap] += cropped_stamp[survey_overlap]
         if not no_analysis:
-            print("not no analysis in render engine")
             # Give this Galaxy its own GalaxyRenderer.
             galaxy.renderer = GalaxyRenderer(galaxy,cropped_stamp,self.survey)
 

--- a/descwl/render.py
+++ b/descwl/render.py
@@ -198,7 +198,8 @@ class Engine(object):
             ('PSF dilution factor is %.6f.' % self.psf_dilution)
             ])
 
-    def render_galaxy(self,galaxy,no_partials = False, calculate_bias = False):
+    def render_galaxy(self,galaxy,no_partials = False, calculate_bias = False,
+                      no_analysis=False):
         """Render a galaxy model for a simulated survey.
 
         Args:
@@ -281,69 +282,74 @@ class Engine(object):
         if survey_overlap.area() == 0:
             raise SourceNotVisible
         self.survey.image[survey_overlap] += cropped_stamp[survey_overlap]
+        if not no_analysis:
+            print("not no analysis in render engine")
+            # Give this Galaxy its own GalaxyRenderer.
+            galaxy.renderer = GalaxyRenderer(galaxy,cropped_stamp,self.survey)
 
-        # Give this Galaxy its own GalaxyRenderer.
-        galaxy.renderer = GalaxyRenderer(galaxy,cropped_stamp,self.survey)
+            # Define the parameter variations we consider for building Fisher matrices.
+            # The names appearing below are args of Galaxy.get_transformed_model().
+            # We do not include 'flux' below since the nominal image is already the
+            # partial derivative wrt flux (after dividing by flux).
+            variations = [
+                ('dx',self.survey.pixel_scale/3.), # arcsecs
+                ('dy',self.survey.pixel_scale/3.), # arcsecs
+                ('ds',0.05), # relative dilation (flux preserving)
+                ('dg1',0.03), # + shear using |g| = (a-b)/(a+b) convention
+                ('dg2',0.03), # x shear using |g| = (a-b)/(a+b) convention
+                ]
 
-        # Define the parameter variations we consider for building Fisher matrices.
-        # The names appearing below are args of Galaxy.get_transformed_model().
-        # We do not include 'flux' below since the nominal image is already the
-        # partial derivative wrt flux (after dividing by flux).
-        variations = [
-            ('dx',self.survey.pixel_scale/3.), # arcsecs
-            ('dy',self.survey.pixel_scale/3.), # arcsecs
-            ('ds',0.05), # relative dilation (flux preserving)
-            ('dg1',0.03), # + shear using |g| = (a-b)/(a+b) convention
-            ('dg2',0.03), # x shear using |g| = (a-b)/(a+b) convention
-            ]
+            # Prepare the datacube that we will return.
+            ncube = 1
 
-        # Prepare the datacube that we will return.
-        ncube = 1
-
-        positions = descwl.analysis.make_positions()
-        if not no_partials:
-            ncube = 1+len(variations)
-            if calculate_bias:
-                 #15 is number of second partials for 5 parameters (no flux).
-                ncube = 1 + len(variations) + 15
-
-        height,width = cropped_stamp.array.shape
-        datacube = np.empty((ncube,height,width))
-        datacube[0] = cropped_stamp.array #flux partial is the same.
-
-        #calculate partials, if requested.
-        if not no_partials:
-            #The nominal image doubles as the flux partial derivative.
-            for i,(pname_i,delta_i) in enumerate(variations):
-                variation_stamp = (galaxy.renderer.draw(**{pname_i: +delta_i}).copy() -
-                                       galaxy.renderer.draw(**{pname_i: -delta_i}))
-                datacube[positions[pname_i]] = variation_stamp.array/(2*delta_i)
-
-                #calculate second partials, if requested.
+            positions = descwl.analysis.make_positions()
+            if not no_partials:
+                ncube = 1+len(variations)
                 if calculate_bias:
-                    for j,(pname_j,delta_j) in enumerate(variations):
-                        if(i==j):
-                            galaxy_2iup = galaxy.renderer.draw(**{pname_i: +2*delta_i}).copy()
-                            galaxy_2idown = galaxy.renderer.draw(**{pname_i: -2*delta_i}).copy()
-                            variation_i_i = galaxy_2iup + galaxy_2idown - 2*galaxy.renderer.draw()
-                            datacube[positions[pname_i,pname_i]] = ((variation_i_i).array/
-                                                                    (2*delta_i)**2)
+                     #15 is number of second partials for 5 parameters (no flux).
+                    ncube = 1 + len(variations) + 15
 
-                        elif(j>i):
-                            galaxy_iup_jup = galaxy.renderer.draw(**{pname_i: +delta_i,
-                                                                  pname_j: +delta_j}).copy()
-                            galaxy_iup_jdown = galaxy.renderer.draw(**{pname_i: +delta_i,
-                                                                       pname_j: -delta_j}).copy()
-                            galaxy_idown_jup = galaxy.renderer.draw(**{pname_i: -delta_i,
-                                                                       pname_j: +delta_j}).copy()
-                            galaxy_idown_jdown = galaxy.renderer.draw(**{pname_i: -delta_i,
-                                                                         pname_j: -delta_j})
+            height,width = cropped_stamp.array.shape
+            datacube = np.empty((ncube,height,width))
+            datacube[0] = cropped_stamp.array #flux partial is the same.
 
-                            variation_i_j = (galaxy_iup_jup + galaxy_idown_jdown -
-                                             galaxy_idown_jup - galaxy_iup_jdown)
-                            datacube[positions[pname_i,pname_j]] = (variation_i_j.array /
-                                                                    (4*delta_i*delta_j))
+            #calculate partials, if requested.
+            if not no_partials:
+                #The nominal image doubles as the flux partial derivative.
+                for i,(pname_i,delta_i) in enumerate(variations):
+                    variation_stamp = (galaxy.renderer.draw(**{pname_i: +delta_i}).copy() -
+                                           galaxy.renderer.draw(**{pname_i: -delta_i}))
+                    datacube[positions[pname_i]] = variation_stamp.array/(2*delta_i)
 
+                    #calculate second partials, if requested.
+                    if calculate_bias:
+                        for j,(pname_j,delta_j) in enumerate(variations):
+                            if(i==j):
+                                galaxy_2iup = galaxy.renderer.draw(**{pname_i: +2*delta_i}).copy()
+                                galaxy_2idown = galaxy.renderer.draw(**{pname_i: -2*delta_i}).copy()
+                                variation_i_i = galaxy_2iup + galaxy_2idown - 2*galaxy.renderer.draw()
+                                datacube[positions[pname_i,pname_i]] = ((variation_i_i).array/
+                                                                        (2*delta_i)**2)
+
+                            elif(j>i):
+                                galaxy_iup_jup = galaxy.renderer.draw(**{pname_i: +delta_i,
+                                                                      pname_j: +delta_j}).copy()
+                                galaxy_iup_jdown = galaxy.renderer.draw(**{pname_i: +delta_i,
+                                                                           pname_j: -delta_j}).copy()
+                                galaxy_idown_jup = galaxy.renderer.draw(**{pname_i: -delta_i,
+                                                                           pname_j: +delta_j}).copy()
+                                galaxy_idown_jdown = galaxy.renderer.draw(**{pname_i: -delta_i,
+                                                                             pname_j: -delta_j})
+
+                                variation_i_j = (galaxy_iup_jup + galaxy_idown_jdown -
+                                                 galaxy_idown_jup - galaxy_iup_jdown)
+                                datacube[positions[pname_i,pname_j]] = (variation_i_j.array /
+                                                                        (4*delta_i*delta_j))
+        else:
+            if self.verbose_render:
+                print("No analysis performed")
+            height, width = cropped_stamp.array.shape
+            datacube = np.empty((1, height, width))
         if self.verbose_render:
             print('Rendered galaxy model for id = %d with z = %.3f' % (
                 galaxy.identifier,galaxy.redshift))

--- a/descwl/survey.py
+++ b/descwl/survey.py
@@ -106,9 +106,6 @@ class Survey(object):
                 self.psf_size_hsm = hsm_results.moments_sigma*self.pixel_scale
             except RuntimeError as e:
                 raise RuntimeError('Unable to calculate adaptive moments of PSF image.')
-        else:
-            if self.verbose_render:
-                print("No analysis performed")
         # Calculate the mean sky background level in detected electrons per pixel.
         self.mean_sky_level = self.get_flux(self.sky_brightness)*self.pixel_scale**2
         # Create an empty image using (0,0) to index the lower-left corner pixel.

--- a/simulate.py
+++ b/simulate.py
@@ -12,6 +12,8 @@ def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--verbose', action = 'store_true',
         help = 'Provide verbose output.')
+    parser.add_argument('--no-analysis', action = 'store_true',
+        help = 'Don\'t run analysis.')
     parser.add_argument('--survey-defaults', action = 'store_true',
         help = 'Print survey camera and observing parameter defaults and exit.')
     parser.add_argument('--memory-trace', action = 'store_true',
@@ -100,8 +102,7 @@ def main():
 
                 except (descwl.model.SourceNotVisible,descwl.render.SourceNotVisible):
                     pass
-
-        results = analyzer.finalize(args.verbose,trace,args.calculate_bias)
+        results = analyzer.finalize(args.verbose,trace,args.calculate_bias,args.no_analysis)
         output.finalize(results,trace)
 
     except RuntimeError as e:

--- a/simulate.py
+++ b/simulate.py
@@ -85,7 +85,9 @@ def main():
 
                 try:
                     galaxy = galaxy_builder.from_catalog(entry,dx,dy,survey.filter_band)
-                    stamps,bounds = render_engine.render_galaxy(galaxy,args.no_partials,args.calculate_bias)
+                    stamps, bounds = render_engine.render_galaxy(
+                        galaxy, args.no_partials, args.calculate_bias,
+                        args.no_analysis)
                     analyzer.add_galaxy(galaxy,stamps,bounds)
                     trace('render')
 


### PR DESCRIPTION
Option to skip analysis and save only the simulated image added.  @dkirkby I added a skip line in analysis.py > OverlapResults , to return an empty table. I still save the header entries so that the add noise function can be run later to the image. 

Are there other ways of speeding things up? Also right now I'm returning an empty table. Can an option be added to return no table? output.py> Writer has an option no_catalog, but I wasn't able to figure out how that is accessed. 