### PR TITLE
Update survey.py (small error in args) 

### DIFF
--- a/descwl/survey.py
+++ b/descwl/survey.py
@@ -479,5 +479,5 @@ class Survey(object):
         for parameter_name in ctor_params:
             if parameter_name in args_dict and args_dict[parameter_name] is not None:
                 ctor_params[parameter_name] = args_dict[parameter_name]
-        return Survey(no_analysis=args['no_analysis'], survey_name=survey_name,
+        return Survey(no_analysis=args_dict['no_analysis'], survey_name=survey_name,
                       filter_band=filter_band,**ctor_params)


### PR DESCRIPTION
Small mistake where `args` was used instead of `args_dict` in `survey.py`, this is now corrected.