### PR TITLE
Add (2-norm) condition numbers to output data information.

### DIFF
--- a/descwl/analysis.py
+++ b/descwl/analysis.py
@@ -841,7 +841,7 @@ class OverlapAnalyzer(object):
                 ('ds_grp',np.float32),
                 ('dg1_grp',np.float32),
                 ('dg2_grp',np.float32),
-                ('cond_num_iso', np.float32), #condition number of individual galaxy fisher matrix. 
+                ('cond_num', np.float32), #condition number of individual galaxy fisher matrix. 
                 ('cond_num_grp', np.float32), #condition number (using 2-norm) from fisher matrix of corresponding group. 
                 # HSM analysis results.
                 ('hsm_sigm',np.float32),
@@ -1070,7 +1070,7 @@ class OverlapAnalyzer(object):
                     data['ds'][galaxy] = data['ds_grp'][galaxy]
                     data['dg1'][galaxy] = data['dg1_grp'][galaxy]
                     data['dg2'][galaxy] = data['dg2_grp'][galaxy]
-                    data['cond_num_iso'][galaxy] = data['cond_num_grp'][galaxy]
+                    data['cond_num'][galaxy] = data['cond_num_grp'][galaxy]
                     if calculate_bias:
                         data['bias_f'][galaxy] = data['bias_f_grp'][galaxy]
                         data['bias_s'][galaxy] = data['bias_s_grp'][galaxy]
@@ -1083,7 +1083,7 @@ class OverlapAnalyzer(object):
                     # Redo the Fisher matrix analysis but ignoring overlapping sources.
                     iso_fisher,iso_covariance,iso_variance,iso_correlation = (
                         results.get_matrices([galaxy]))
-                    cond_num_iso = np.linalg.cond(iso_fisher)
+                    cond_num = np.linalg.cond(iso_fisher)
                     # snr_iso and snr_isof will be zero if the Fisher matrix is not invertible or
                     # yields any negative variances. Errors on s,g1,g2 will be np.inf.
                     data['snr_iso'][galaxy] = flux*np.sqrt(iso_fisher[dflux_index,dflux_index])
@@ -1091,7 +1091,7 @@ class OverlapAnalyzer(object):
                     data['ds'][galaxy] = np.sqrt(iso_variance[ds_index])
                     data['dg1'][galaxy] = np.sqrt(iso_variance[dg1_index])
                     data['dg2'][galaxy] = np.sqrt(iso_variance[dg2_index])
-                    data['cond_num_iso'][galaxy] = cond_num_iso
+                    data['cond_num'][galaxy] = cond_num
 
                     if calculate_bias:
                         iso_bias = results.get_bias([galaxy], iso_covariance)
@@ -1101,6 +1101,7 @@ class OverlapAnalyzer(object):
                         data['bias_g2'][galaxy] = iso_bias[dg2_index]
                         data['bias_x'][galaxy] = iso_bias[dx_index]
                         data['bias_y'][galaxy] = iso_bias[dy_index]
+
             # Order group members by decreasing isolated S/N.
             sorted_indices = group_indices[np.argsort(data['snr_iso'][grp_members])[::-1]]
             data['grp_rank'][sorted_indices] = np.arange(grp_size,dtype = np.int16)

--- a/docs/output.rst
+++ b/docs/output.rst
@@ -104,6 +104,8 @@ dg2         float32 Error on shear x component (nominal g2=0) marginalized over 
 ds_grp      float32 Same as ds but also marginalizing over parameters of any overlapping sources (e)
 dg1_grp     float32 Same as dg1 but also marginalizing over parameters of any overlapping sources (e)
 dg2_grp     float32 Same as dg2 but also marginalizing over parameters of any overlapping sources (e)
+cond_num    float32 Condition number of fisher matrix corresponding to this individual source. 
+cond_num_grp float32 Condition number of the fisher matrix of the group this source belongs to. 
 ----------- ------- ------------------------------------------------------------------------------------
 **Bias on parameters** (Calculated from Fisher Formalism)
 --------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Hi David and Javier, 

Pat and I have been investigating some of the the more fundamental issues that led us to using the pseudo-inverse in the first place. Our conclusions for the pseudo-inverse (also from Javier's tests) seem to be that the pseudo-inverse is not a magic bullet, and there are some other problems that need to be addressed. 

More recently, we revisited this paper https://arxiv.org/abs/gr-qc/0703086 on Use and Abuse of the Fisher Matrix  and we decided to  investigate condition numbers of fisher matrices further -- since they can lead to huge losses in accuracy of fisher elements (see section IV the above paper). 

Once we have investigated this a bit more, we will give you an update. For now I just wanted to propose adding the condition numbers of the fisher matrices of a group and of individual galaxies to the output table, I think it will be helpful going forward. Since the condition number gives us a sense of how ill-defined a matrix is when trying to invert it. 

Could you review my code and see if there is anything missing or incorrect? Thanks in advance! 