### PR TITLE
Changed inv to pinv to deal with stars

### DIFF
--- a/descwl/model.py
+++ b/descwl/model.py
@@ -417,8 +417,6 @@ class Star(object):
                 the requested transforms applied.
         """
         return (self.profile
-            .dilate(1 + ds)
-            .shear(g1 = dg1,g2 = dg2)
             .shift(dx = self.dx_arcsecs + dx,dy = self.dy_arcsecs + dy))
 
 class StarBuilder(object):


### PR DESCRIPTION
This PR addresses some of the issues found when computing Neff in the presence of stars. We change inv to pinv in order to deal with the reduced number of degrees of freedom, and we fix 3 dof (shape and size) for stars.